### PR TITLE
Address CVE-2020-8130

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gem 'sinatra', '~> 2.0.8.1'
 gem 'snmp', '~> 1.3.2'
 
 group :development, :test do
-  gem 'pry', '~> 0.11.0'
+  gem 'pry', '~> 0.13.0'
 end
 
 group :test do
-  gem 'rspec-core', '~> 2.8.0'
-  gem 'rspec-expectations', '~> 2.8.0'
-  gem 'rspec-mocks', '~> 2.8.0'
+  gem 'rspec-core', '~> 3.9.0'
+  gem 'rspec-expectations', '~> 3.9.0'
+  gem 'rspec-mocks', '~> 3.9.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,21 +2,26 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
-    diff-lcs (1.1.3)
-    method_source (0.8.2)
+    diff-lcs (1.3)
+    method_source (1.0.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    pry (0.11.0)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
+    pry (0.13.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
-    rake (0.9.2.2)
-    rspec-core (2.8.0)
-    rspec-expectations (2.8.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.8.0)
+    rake (13.0.1)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     ruby2_keywords (0.0.2)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
@@ -30,11 +35,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  pry (~> 0.11.0)
+  pry (~> 0.13.0)
   rake
-  rspec-core (~> 2.8.0)
-  rspec-expectations (~> 2.8.0)
-  rspec-mocks (~> 2.8.0)
+  rspec-core (~> 3.9.0)
+  rspec-expectations (~> 3.9.0)
+  rspec-mocks (~> 3.9.0)
   sinatra (~> 2.0.8.1)
   snmp (~> 1.3.2)
 

--- a/spec/snitch_spec.rb
+++ b/spec/snitch_spec.rb
@@ -3,13 +3,13 @@ require 'snitch'
 
 describe Snitch do
   describe "#connected_clients" do
-    let(:row) { double 'row', value: stub(to_mac: address) }
+    let(:row) { double 'row', value: double(to_mac: address) }
     let(:octal) { "\x04\x06p\x81\x05\x06\xB5\xE8" }
     let(:address) { "70:81:05:06:B5:E8" }
     let(:snitch) { Snitch.new }
 
     before do
-      YAML.stub load_file: { '70:81:05:06:B5:E8' => client }
+      allow(YAML).to receive(:load_file).and_return('70:81:05:06:B5:E8' => client)
     end
 
     subject { snitch.connected_clients }
@@ -19,16 +19,16 @@ describe Snitch do
 
       let(:manager) do
         double('manager').tap do |manager|
-          manager.stub(:walk).and_yield(row)
+          allow(manager).to receive(:walk).and_yield(row)
         end
       end
 
       before do
-        SNMP::Manager.should_receive(:open).and_yield(manager)
+        expect(SNMP::Manager).to receive(:open).and_yield(manager)
       end
 
       it "returns current client list array" do
-        should eq [client]
+        expect(subject).to eq [client]
       end
     end
 
@@ -36,11 +36,11 @@ describe Snitch do
       let(:client) { [] }
 
       before do
-        SNMP::Manager.should_receive(:open).and_raise(SocketError)
+        expect(SNMP::Manager).to receive(:open).and_raise(SocketError)
       end
 
       it "returns an empty array" do
-        should eq []
+        expect(subject).to eq []
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end


### PR DESCRIPTION
This also upgrades the rspec and pry dependencies because it is more compatible with modern rake. I had to switch the syntax from should to expect in the test cases.